### PR TITLE
chore: update whatsapp links to point to new whatsapp page

### DIFF
--- a/index.html
+++ b/index.html
@@ -290,7 +290,7 @@
 				</a>
 			</p>
 			<p>
-				<a href='https://bkhrc-whatsapp-gateway.vercel.app/'>
+				<a href='https://www.bkhrc.org/whatsapp.html'>
 					WHATSAPP
 				</a>
 			</p>

--- a/schedule.html
+++ b/schedule.html
@@ -195,7 +195,7 @@
 			<br />
 
 			<h3>Special Runs</h3>
-			<p>Saturday: Long Runs, community planned in <a href='https://bkhrc-whatsapp-gateway.vercel.app/'> WhatsApp</a>
+			<p>Saturday: Long Runs, community planned in <a href='https://www.bkhrc.org/whatsapp.html'>WhatsApp</a>
 			</p>
 			<p>Sunday, 9am, 10 pace groups starting at <a href='https://maps.app.goo.gl/x5RPyQkCXeKqwdnYA'>Pier 5</a></p>
 
@@ -214,7 +214,7 @@
 					</a>
 				</p>
 				<p>
-					<a href='https://bkhrc-whatsapp-gateway.vercel.app/'>
+					<a href='https://www.bkhrc.org/whatsapp.html'>
 						WHATSAPP
 					</a>
 				</p>

--- a/whatsapp.html
+++ b/whatsapp.html
@@ -417,7 +417,7 @@
 					</a>
 				</p>
 				<p>
-					<a href='https://bkhrc-whatsapp-gateway.vercel.app/'>
+					<a href='https://www.bkhrc.org/whatsapp.html'>
 						WHATSAPP
 					</a>
 				</p>


### PR DESCRIPTION
Once the recaptcha is updated to allow the bkhrc.org domain and the recaptcha is working we can merge this PR to update the links on the pages to point to the /whatsapp.html route instead of the separate page: https://bkhrc-whatsapp-gateway.vercel.app so that everything is hosted on the same site